### PR TITLE
Use the new namespace for the Asgard modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.6",
     "composer/installers": "~1.0",
-    "asgardcms/core-module": "~2.0"
+    "idavoll/core-module": "~2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
I forgot about this module until I noticed `asgardcms/core` was installed instead of `idavoll/core` today.