### PR TITLE
Fix exception when marking all as read

### DIFF
--- a/Http/Controllers/Admin/NotificationsController.php
+++ b/Http/Controllers/Admin/NotificationsController.php
@@ -59,8 +59,7 @@ class NotificationsController extends AdminBaseController
     {
         $this->notification->markAllAsReadForUser($this->auth->id());
 
-        flash(trans('notification::messages.all notifications marked as read'));
-
-        return redirect()->route('admin.notification.notification.index');
+        return redirect()->route('admin.notification.notification.index')
+            ->withSuccess(trans('notification::messages.all notifications marked as read'));
     }
 }


### PR DESCRIPTION
When trying to mark all notifications as read, the following exception is thrown:

```
Call to undefined function Modules\Notification\Http\Controllers\Admin\flash()
```

This was fixed in v3, but not backported to v2.